### PR TITLE
Load efi graphics drivers in efi mode

### DIFF
--- a/grub.cfg
+++ b/grub.cfg
@@ -6,9 +6,14 @@
 insmod font
 if loadfont unicode ; then
   if keystatus --shift ; then true ; else
+    if [ "${grub_platform}" == "efi" ]; then
+      insmod efi_gop
+      insmod efi_uga
+    else
+      insmod vbe
+      insmod vga
+    fi
     insmod gfxterm
-    insmod vbe
-    insmod vga
     set gfxmode=auto
     set gfxpayload=auto
     terminal_output gfxterm


### PR DESCRIPTION
On my UEFI-only system (Surface Pro 3) I was getting

```
error: no suitable mode found
```

and non-gui OSs showed nothing on the screen.

Inspiration for the fix from https://wiki.archlinux.org/index.php/GRUB#.22No_suitable_mode_found.22_error