### PR TITLE
Greatly speed up mkfs.ntfs

### DIFF
--- a/makeUSB.sh
+++ b/makeUSB.sh
@@ -264,6 +264,10 @@ fi
 # Format data partition
 printf 'Formatting data partition as %s on %s... ' \
     "$data_fmt" "${usb_dev}${data_part}"
+if [ "$data_fmt" = "ntfs" ]; then
+	# Use mkntfs quick format
+	data_fmt="ntfs -f"
+fi
 if mkfs.${data_fmt} "${usb_dev}${data_part}" >> "$log_file" 2>&1; then
 	printf 'OK\n'
 else


### PR DESCRIPTION
I added the quick format flag to `mkfs.ntfs` so that `mkntfs` does not erase the whole partition.

## Benefits

- Much faster NTFS formatting, especially on large drives
- Saves flash writes on flash drives and solid-state drives

## Drawbacks

- Not extensible to other `mkfs` flags; implemented as a one-off `if` condition
- Last mention/use of `$data_fmt` includes a flag and is not just the data file system format, which somewhat reduces code readability