### PR TITLE
Added Fedora 25 Live, removed Fedora 24 Live

### DIFF
--- a/grub.d/fedora-live.cfg
+++ b/grub.d/fedora-live.cfg
@@ -1,26 +1,8 @@
 # Fedora Live Workstation (https://getfedora.org/)
-if [ -e "$isopath/Fedora-Workstation-Live-i386-24-1.2.iso" ]; then
+if [ -e $isopath/Fedora-Workstation-Live-*.iso ]; then
   submenu "Fedora ->" {
-    set isofile="$isopath/Fedora-Workstation-Live-i386-24-1.2.iso"
-    loopback loop $isofile
-    menuentry "Start Fedora-Workstation-Live 24" {
-      bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-24-1-2 rd.live.image quiet"
-      linux (loop)/isolinux/vmlinuz $bootoptions
-      initrd (loop)/isolinux/initrd.img
-    }
-    menuentry "Start Fedora-Workstation-Live 24 in basic graphics mode" {
-      bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-24-1-2 rd.live.image nomodeset quiet"
-      linux (loop)/isolinux/vmlinuz $bootoptions
-      initrd (loop)/isolinux/initrd.img
-    }
-    menuentry "Test this media & start Fedora-Workstation-Live 24" {
-      bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-24-1-2 rd.live.image rd.live.check quiet"
-      linux (loop)/isolinux/vmlinuz $bootoptions
-      initrd (loop)/isolinux/initrd.img
-    }
-    menuentry "Run a memory test" {
-      bootoptions=""
-      linux16 (loop)/isolinux/memtest $bootoptions
-    }
+    for configfile in $prefix/grub.d/fedora.d/*-live.cfg; do
+      source $configfile
+    done
   }
 fi

--- a/grub.d/fedora.d/25-live.cfg
+++ b/grub.d/fedora.d/25-live.cfg
@@ -1,0 +1,58 @@
+if [ -a $isopath/Fedora-Workstation-Live-*-25-*.iso ]; then
+  submenu "Fedora Workstation Live 25 ->" {
+
+# Fedora-Workstation-Live-x86_64-25-1.3.iso
+#   Download: https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-25-1.3.iso
+#   SHA256:   818017f42a2741cfaf20e94aecf6a63d1b995abfdaff5917df7218d0d89976a7
+    if [ -e "$isopath/Fedora-Workstation-Live-x86_64-25-1.3.iso" ]; then
+      set isofile="$isopath/Fedora-Workstation-Live-x86_64-25-1.3.iso"
+      loopback loop $isofile
+      menuentry "Start Fedora Workstation Live 25 (64-bit)" {
+        bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-25-1-3 rd.live.image quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Start Fedora Workstation Live 25 in basic graphics mode (64-bit)" {
+        bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-25-1-3 rd.live.image nomodeset quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Test this media & start Fedora Workstation Live 25 (64-bit)" {
+        bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-25-1-3 rd.live.image rd.live.check quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Run a memory test" {
+        bootoptions=""
+        linux16 (loop)/isolinux/memtest $bootoptions
+      }
+    fi
+
+# Fedora-Workstation-Live-i386-25-1.3.iso
+#   Download: https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/i386/iso/Fedora-Workstation-Live-i386-25-1.3.iso
+#   SHA256:   da4a07c6758070f9ada0458664436e5d4a8bc19a0480c8dd03ccf9afd21b5fef
+    if [ -e "$isopath/Fedora-Workstation-Live-i386-25-1.3.iso" ]; then
+      set isofile="$isopath/Fedora-Workstation-Live-i386-25-1.3.iso"
+      loopback loop $isofile
+      menuentry "Start Fedora Workstation Live 25 (32-bit)" {
+        bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-25-1-3 rd.live.image quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Start Fedora Workstation Live 25 in basic graphics mode (32-bit)" {
+        bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-25-1-3 rd.live.image nomodeset quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Test this media & start Fedora Workstation Live 25 (32-bit)" {
+        bootoptions="iso-scan/filename=$isofile root=live:CDLABEL=Fedora-WS-Live-25-1-3 rd.live.image rd.live.check quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Run a memory test" {
+        bootoptions=""
+        linux16 (loop)/isolinux/memtest $bootoptions
+      }
+    fi
+  }
+fi


### PR DESCRIPTION
- NEW: Added Fedora Workstation Live 25 (64-bit)
- NEW: Added Fedora Workstation Live 25 (32-bit)
- MOD: Removed Fedora Workstation Live 24 (32-bit)
- MOD: Put Fedora configuration files in grub.d/fedora.d
- XXX: Data file system must not be NTFS because Fedora did not package Dracut with NTFS mounting support