### PR TITLE
add configuration for debian testing images

### DIFF
--- a/grub.d/debian.d/testing.cfg
+++ b/grub.d/debian.d/testing.cfg
@@ -3,6 +3,7 @@
 # refer to https://www.debian.org/releases/stable/amd64/ch05s01.html.en
 # refer to https://lists.debian.org/debian-user/2012/12/msg00194.html
 # for testing images, an extra installer is needed to find what iso you would like to install.
+# so, remember to download vmlinuz and initrd.gz from https://d-i.debian.org/daily-images/amd64/daily/
 if [ -e $isopath/debian-testing-amd64*.iso ]; then
   submenu "Debian testing ->" {
     if cpuid -l ; then # Check whether CPU is 64-bit

--- a/grub.d/debian.d/testing.cfg
+++ b/grub.d/debian.d/testing.cfg
@@ -2,31 +2,14 @@
 # Debian testing (https://d-i.debian.org/daily-images/amd64/daily/)
 # refer to https://www.debian.org/releases/stable/amd64/ch05s01.html.en
 # refer to https://lists.debian.org/debian-user/2012/12/msg00194.html
-if [ -e $isopath/debian-testing*.iso ]; then
+# for testing images, an extra installer is needed to find what iso you would like to install.
+if [ -e $isopath/debian-testing-amd64*.iso ]; then
   submenu "Debian testing ->" {
-    if cpuid -l ; # Check whether CPU is 64-bit
-      if [ -e "$isopath/debian-testing-amd64-xfce-CD-1.iso" ]; then
-        menuentry "debian-testing-amd64-xfce-CD-1.iso" {
-          set isofile="$isopath/debian-testing-amd64-xfce-CD-1.iso"
-          bootoptions="iso raw"
-          linux16 $prefix/memdisk $bootoptions
-          initrd16 $isofile
-        }
-      fi
-      if [ -e "$isopath/debian-testing-amd64-netinst.iso" ]; then
-        menuentry "hd-media" {
+    if cpuid -l ; then # Check whether CPU is 64-bit
+        menuentry "hd-media-installer" {
           linux $isopath/vmlinuz BOOT_DEBUG
           initrd $isopath/initrd.gz
         }
-      fi
-      if [ -e "$isopath/debian-testing-amd64-netinst.iso" ]; then
-        menuentry "debian-testing-amd64-netinst.iso" {
-          set isofile="$isopath/debian-testing-amd64-netinst.iso"
-          bootoptions="iso raw"
-          linux16 $prefix/memdisk $bootoptions
-          initrd16 $isofile
-        }
-      fi
     fi
   }
 fi

--- a/grub.d/debian.d/testing.cfg
+++ b/grub.d/debian.d/testing.cfg
@@ -1,0 +1,32 @@
+# Debian testing (http://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/)
+# Debian testing (https://d-i.debian.org/daily-images/amd64/daily/)
+# refer to https://www.debian.org/releases/stable/amd64/ch05s01.html.en
+# refer to https://lists.debian.org/debian-user/2012/12/msg00194.html
+if [ -e $isopath/debian-testing*.iso ]; then
+  submenu "Debian testing ->" {
+    if cpuid -l ; # Check whether CPU is 64-bit
+      if [ -e "$isopath/debian-testing-amd64-xfce-CD-1.iso" ]; then
+        menuentry "debian-testing-amd64-xfce-CD-1.iso" {
+          set isofile="$isopath/debian-testing-amd64-xfce-CD-1.iso"
+          bootoptions="iso raw"
+          linux16 $prefix/memdisk $bootoptions
+          initrd16 $isofile
+        }
+      fi
+      if [ -e "$isopath/debian-testing-amd64-netinst.iso" ]; then
+        menuentry "hd-media" {
+          linux $isopath/vmlinuz BOOT_DEBUG
+          initrd $isopath/initrd.gz
+        }
+      fi
+      if [ -e "$isopath/debian-testing-amd64-netinst.iso" ]; then
+        menuentry "debian-testing-amd64-netinst.iso" {
+          set isofile="$isopath/debian-testing-amd64-netinst.iso"
+          bootoptions="iso raw"
+          linux16 $prefix/memdisk $bootoptions
+          initrd16 $isofile
+        }
+      fi
+    fi
+  }
+fi


### PR DESCRIPTION
add configuration for debian testing images

verified with debian-testing-amd64-netinst.iso
with the needed installer:
https://d-i.debian.org/daily-images/amd64/daily/hd-media/boot.img.gz
https://d-i.debian.org/daily-images/amd64/daily/hd-media/initrd.gz