### PR TITLE
add generic fallback to arch linux config

### DIFF
--- a/grub.d/arch.d/generic.cfg
+++ b/grub.d/arch.d/generic.cfg
@@ -1,0 +1,20 @@
+# fallback
+if [ -e $isopath/archlinux-* ]; then
+  submenu "[Fallback] ->" {
+    for isofile in $isopath/archlinux-*; do
+      loopback loop $isofile
+      menuentry "[$isofile] Arch Linux (i686)" {
+        bootoptions="img_dev=$imgdevpath img_loop=$isofile earlymodules=loop"
+        linux (loop)/arch/boot/i686/vmlinuz $bootoptions
+        initrd (loop)/arch/boot/i686/archiso.img
+      }
+      if cpuid -l ; then # Check whether CPU is 64-bit
+          menuentry "[$isofile] Arch Linux (x86_64)" {
+            bootoptions="img_dev=$imgdevpath img_loop=$isofile earlymodules=loop"
+            linux (loop)/arch/boot/x86_64/vmlinuz $bootoptions
+            initrd (loop)/arch/boot/x86_64/archiso.img
+          }
+      fi
+    done
+  }
+fi


### PR DESCRIPTION
generic.cfg:
Finds every archlinux iso and
creates a boot entire for it.
Can only find isos if there name
starts with "archlinux-".

submenus not working correctly at the moment,
but it should be enought for a nice fallback.