### PR TITLE
fixed using gentoo live-dvd and added support for minimal install images

### DIFF
--- a/grub.d/gentoo.d/install-minimal-generic.cfg
+++ b/grub.d/gentoo.d/install-minimal-generic.cfg
@@ -1,6 +1,6 @@
 # Generic entries for unknown ISO files
-if [ -e $isopath/install-*-minimal-*.iso ]; then
-  for isofile in $isopath/install-*-minimal-*.iso; do
+if [ -e $isopath/gentoo-install-*-minimal-*.iso ]; then
+  for isofile in $isopath/gentoo-install-*-minimal-*.iso; do
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname ->" "$isofile" {
       iso_path="$2"

--- a/grub.d/gentoo.d/install-minimal-generic.cfg
+++ b/grub.d/gentoo.d/install-minimal-generic.cfg
@@ -1,0 +1,24 @@
+# Generic entries for unknown ISO files
+if [ -e $isopath/install-*-minimal-*.iso ]; then
+  for isofile in $isopath/install-*-minimal-*.iso; do
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname ->" "$isofile" {
+      iso_path="$2"
+      loopback loop "$iso_path"
+      menuentry "gentoo" {
+        bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap looptype=squashfs loop=/image.squashfs cdroot vga=791"
+        linux (loop)/isolinux/gentoo $bootoptions
+        initrd (loop)/isolinux/gentoo.igz
+      }
+      menuentry "gentoo-nofb" {
+        bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap looptype=squashfs loop=/image.squashfs cdroot"
+        linux (loop)/isolinux/gentoo $bootoptions
+        initrd (loop)/isolinux/gentoo.igz
+      }
+      menuentry "memtest86" {
+        bootoptions=""
+        linux16 (loop)/boot/memtest86 $bootoptions
+      }
+    }
+  done
+fi

--- a/grub.d/gentoo.d/livedvd-generic.cfg
+++ b/grub.d/gentoo.d/livedvd-generic.cfg
@@ -1,6 +1,6 @@
 # Generic entries for unknown ISO files
-if [ -e $isopath/livedvd-*.iso ]; then
-  for isofile in $isopath/livedvd-*.iso; do
+if [ -e $isopath/gentoo-livedvd-*.iso ]; then
+  for isofile in $isopath/gentoo-livedvd-*.iso; do
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname ->" "$isofile" {
       iso_path="$2"

--- a/grub.d/gentoo.d/livedvd-generic.cfg
+++ b/grub.d/gentoo.d/livedvd-generic.cfg
@@ -1,32 +1,20 @@
 # Generic entries for unknown ISO files
-if [ -e $isopath/gentoo-livedvd-*.iso ]; then
-  for isofile in $isopath/gentoo-livedvd-*.iso; do
+if [ -e $isopath/livedvd-*.iso ]; then
+  for isofile in $isopath/livedvd-*.iso; do
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname ->" "$isofile" {
       iso_path="$2"
       loopback loop "$iso_path"
-      menuentry "Gentoo x86" {
+      menuentry "Gentoo" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot console=tty1"
         linux (loop)/isolinux/gentoo $bootoptions
         initrd (loop)/isolinux/gentoo.xz
       }
-      menuentry "Gentoo x86 nofb" {
+      menuentry "Gentoo nofb" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot nomodeset"
         linux (loop)/isolinux/gentoo $bootoptions
         initrd (loop)/isolinux/gentoo.xz
       }
-      if cpuid -l ; then # Check whether CPU is 64-bit
-        menuentry "Gentoo x86 amd64" {
-          bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot console=tty1"
-          linux (loop)/isolinux/gentoo64 $bootoptions
-          initrd (loop)/isolinux/gentoo64.xz
-        }
-        menuentry "Gentoo x86 amd64 nofb" {
-          bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs  cdroot nomodeset"
-          linux (loop)/isolinux/gentoo64 $bootoptions
-          initrd (loop)/isolinux/gentoo64.xz
-        }
-      fi
       menuentry "Memory testing utility - memtest86+" {
         bootoptions=""
         linux16 (loop)/boot/memtest86 $bootoptions


### PR DESCRIPTION
To make a long story short, I needed some bootable USB key that was EFI capable and would provide me a decent gentoo image. This didn't work out as expected as there was no support for the minimal installation image and the support for the live DVD image was expecting an erroneous file name (which may have been by intentional due to the distro-wise ambiguous naming scheme chosen by gentoo maintainers/ISO creators) and expected the image to contain both architectures, x86 as well as amd64.

Please have a look at the changes resulting from the pull request.

* gentoo DVD images were pulled using the wrong file name, this is fixed
* gentoo DVD images do not come in a mixed amd64/x86 flavour anymore, images are now considered platform specific
* support for gentoo minimal installation images has been added