### PR TITLE
add arch linux 64-bit only

### DIFF
--- a/grub.d/arch.d/x86_64.cfg
+++ b/grub.d/arch.d/x86_64.cfg
@@ -1,0 +1,16 @@
+
+# 64-Bit only
+if [ -e $isopath/archlinux-*-x86_64.iso ]; then
+  for isofile in $isopath/archlinux-*-x86_64.iso; do
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname ->" "$isofile" {
+      iso_path="$2"
+      loopback loop "$iso_path"
+      menuentry "Arch Linux (x86_64)" {
+        bootoptions="img_dev=$imgdevpath img_loop=$iso_path earlymodules=loop"
+        linux (loop)/arch/boot/x86_64/vmlinuz $bootoptions
+        initrd (loop)/arch/boot/x86_64/archiso.img
+      }
+    }
+  done
+fi


### PR DESCRIPTION
Support for arch linux 64-bit only images.
Does the same as the old script "dual-generic.cfg",
but searches for "archlinux-*-x86_64.iso".