### PR TITLE
Add mbusb.d/rfremix.d/* support

### DIFF
--- a/mbusb.d/rfremix.d/server-generic.cfg
+++ b/mbusb.d/rfremix.d/server-generic.cfg
@@ -1,0 +1,34 @@
+for isofile in $isopath/RFRemix-Server-DVD*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname ->" "$isofile" {
+      iso_path="$2"
+      loopback loop "$iso_path"
+      probe --label --set=cd_label (loop)
+      menuentry "Install RFRemix Server" {
+        bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Test this media & install RFRemix Server" {
+        bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label rd.live.check quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Install RFRemix in basic graphics mode" {
+        bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label nomodeset quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Rescue a RFRemix system" {
+        bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label rescue quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Run a memory test" {
+        bootoptions=""
+        linux16 (loop)/isolinux/memtest $bootoptions
+      }
+    }
+  fi
+done

--- a/mbusb.d/rfremix.d/workstation-generic.cfg
+++ b/mbusb.d/rfremix.d/workstation-generic.cfg
@@ -1,0 +1,29 @@
+for isofile in $isopath/RFRemix-Workstation-Live-*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname ->" "$isofile" {
+      iso_path="$2"
+      loopback loop "$iso_path"
+      probe --label --set=cd_label (loop)
+      menuentry "Start RFRemix Workstation Live" {
+        bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Start RFRemix Workstation Live in basic graphics mode" {
+        bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image nomodeset quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Test this media & start RFRemix Workstation Live" {
+        bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image rd.live.check quiet"
+        linux (loop)/isolinux/vmlinuz $bootoptions
+        initrd (loop)/isolinux/initrd.img
+      }
+      menuentry "Run a memory test" {
+        bootoptions=""
+        linux16 (loop)/isolinux/memtest $bootoptions
+      }
+    }
+  fi
+done


### PR DESCRIPTION
The same as #107 fixed for new format.

A few comments.

Almost all except iso file name the same as in fedora. I split rfremix from fedora. My logic the same as centos != rhel 