### PR TITLE
SpinRite support

### DIFF
--- a/mbusb.d/spinrite.d/generic.cfg
+++ b/mbusb.d/spinrite.d/generic.cfg
@@ -1,0 +1,11 @@
+for isofile in $isopath/SpinRite*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    menuentry "$isoname (memdisk)" "$isofile" {
+      iso_path="$2"
+      bootoptions="iso raw"
+      linux16 $prefix/memdisk $bootoptions
+      initrd16 $iso_path
+    }
+  fi
+done


### PR DESCRIPTION
Adding [SpinRite](https://www.grc.com/sr/spinrite.htm) support. Script copied from [here](https://www.linuxquestions.org/questions/linux-newbie-8/need-a-way-to-run-spinrite-6-via-grub2-can-do-either-iso-or-image-file-4175546458/) and modified to work with the scripts structure in this repo. It seems to be working well. Successfully running SpinRite.