### PR TITLE
Ubuntu server support

### DIFF
--- a/mbusb.d/ubuntu.d/server-generic.cfg
+++ b/mbusb.d/ubuntu.d/server-generic.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/ubuntu-*-server-*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname (loopback.cfg) ->" "$isofile" {
+      iso_path="$2"
+      export iso_path
+      search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      root=(loop)
+      configfile /boot/grub/loopback.cfg
+      loopback --delete loop
+    }
+  fi
+done


### PR DESCRIPTION
Ubuntu desktop iso files are already supported. This adds ubuntu server iso files support by changing the iso pattern to `ubuntu-*-server-*.iso` in `server-generic.cfg`. Not sure if desktop and server configurations can be combined to `ubuntu-*.iso` since that would match netbook ubuntu variations in `netboot-generic64.cfg` and `netboot-generic32.cfg`.