### PR TITLE
Add support for Arch Linux Netboot

### DIFF
--- a/mbusb.d/arch.d/kernel-generic.cfg
+++ b/mbusb.d/arch.d/kernel-generic.cfg
@@ -1,0 +1,9 @@
+## this is the iPXE kernel-like image of Arch Linux,
+set lkrnname=ipxe.28ebfe8a66ac.lkrn
+## and the file name seems to be a fixed value according to https://www.archlinux.org/releng/netboot/
+set lkrnloc=${isopath}/${lkrnname}
+if [ -e ${lkrnloc} ]; then
+	menuentry "Arch Linux Netboot (iPXE)" {
+		linux16 ${lkrnloc}
+	}
+fi


### PR DESCRIPTION
Seeing that the cfg files in mbusb.d/netboot.xyz.d may apply on Arch's iPXE Netboot, I decided to add a support for it. Already been tested it on my PC and it works pretty well. Please see here [https://www.archlinux.org/releng/netboot/](url) for details.