### PR TITLE
makeUSB.sh: allow installs to relative directories other than /boot

### DIFF
--- a/makeUSB.sh
+++ b/makeUSB.sh
@@ -21,7 +21,7 @@ data_fmt="vfat"
 data_size=""
 efi_mnt=""
 data_mnt=""
-data_subdir="" # could be "boot"
+data_subdir="boot"
 repo_dir=""
 tmp_dir="${TMPDIR-/tmp}"
 
@@ -34,12 +34,12 @@ showUsage() {
 	 device                         Device to modify (e.g. /dev/sdb)
 	 fs-type                        Filesystem type for the data partition [ext3|ext4|vfat|ntfs]
 	 data-size                      Data partition size (e.g. 5G)
-	  -d,  --subdirectory           Data subdirectory (e.g. "boot")
 	  -b,  --hybrid                 Create a hybrid MBR
 	  -c,  --clone                  Clone Git repository on the device
 	  -e,  --efi                    Enable EFI compatibility
 	  -i,  --interactive            Launch gdisk to create a hybrid MBR
 	  -h,  --help                   Display this message
+	  -s,  --subdirectory <NAME>    Specify a data subdirectory (e.g. "boot" or "")
 
 	EOF
 }
@@ -87,11 +87,6 @@ while [ "$#" -gt 0 ]; do
 			showUsage
 			exit 0
 			;;
-		-d|--subdirectory)
-			data_subdir="$2"
-			shift
-			shift
-			;;
 		-b|--hybrid)
 			hybrid=1
 			shift
@@ -107,6 +102,11 @@ while [ "$#" -gt 0 ]; do
 			;;
 		-i|--interactive)
 			interactive=1
+			shift
+			;;
+		-s|--subdirectory)
+			data_subdir="$2"
+			shift
 			shift
 			;;
 		/dev/*)

--- a/makeUSB.sh
+++ b/makeUSB.sh
@@ -21,6 +21,7 @@ data_fmt="vfat"
 data_size=""
 efi_mnt=""
 data_mnt=""
+data_subdir="" # could be "boot"
 repo_dir=""
 tmp_dir="${TMPDIR-/tmp}"
 
@@ -33,6 +34,7 @@ showUsage() {
 	 device                         Device to modify (e.g. /dev/sdb)
 	 fs-type                        Filesystem type for the data partition [ext3|ext4|vfat|ntfs]
 	 data-size                      Data partition size (e.g. 5G)
+	  -d,  --subdirectory           Data subdirectory (e.g. "boot")
 	  -b,  --hybrid                 Create a hybrid MBR
 	  -c,  --clone                  Clone Git repository on the device
 	  -e,  --efi                    Enable EFI compatibility
@@ -84,6 +86,11 @@ while [ "$#" -gt 0 ]; do
 		-h|--help)
 			showUsage
 			exit 0
+			;;
+		-d|--subdirectory)
+			data_subdir="$2"
+			shift
+			shift
 			;;
 		-b|--hybrid)
 			hybrid=1
@@ -266,45 +273,45 @@ mount "${usb_dev}${data_part}" "$data_mnt" || cleanUp 10
 # Install GRUB for EFI
 [ "$eficonfig" -eq 1 ] && \
     { $grub_cmd --target=x86_64-efi --efi-directory="$efi_mnt" \
-    --boot-directory="${data_mnt}/boot" --removable --recheck \
+    --boot-directory="${data_mnt}/${data_subdir}" --removable --recheck \
     || cleanUp 10; }
 
 # Install GRUB for BIOS
 $grub_cmd --force --target=i386-pc \
-    --boot-directory="${data_mnt}/boot" --recheck "$usb_dev" \
+    --boot-directory="${data_mnt}/${data_subdir}" --recheck "$usb_dev" \
     || cleanUp 10
 
 # Install fallback GRUB
 $grub_cmd --force --target=i386-pc \
-    --boot-directory="${data_mnt}/boot" --recheck "${usb_dev}${data_part}" \
+    --boot-directory="${data_mnt}/${data_subdir}" --recheck "${usb_dev}${data_part}" \
     || true
 
 # Create necessary directories
-mkdir -p "${data_mnt}/boot/isos" || cleanUp 10
+mkdir -p "${data_mnt}/${data_subdir}/isos" || cleanUp 10
 
 if [ "$clone" -eq 1 ]; then
 	# Clone Git repository
 	(cd "$repo_dir" && \
 	    git clone https://github.com/aguslr/multibootusb . && \
-	    mv .git* * "${data_mnt}"/boot/grub*/) \
+	    mv .git* * "${data_mnt}/${data_subdir}"/grub*/) \
 	    || cleanUp 10
 else
 	# Copy files
-	cp -R ./mbusb.* "${data_mnt}"/boot/grub*/ \
+	cp -R ./mbusb.* "${data_mnt}/${data_subdir}"/grub*/ \
 	    || cleanUp 10
 	# Copy example configuration for GRUB
-	cp ./grub.cfg.example "${data_mnt}"/boot/grub*/ \
+	cp ./grub.cfg.example "${data_mnt}/${data_subdir}"/grub*/ \
 	    || cleanUp 10
 fi
 
 # Rename example configuration
-( cd "${data_mnt}"/boot/grub*/ && cp grub.cfg.example grub.cfg ) \
+( cd "${data_mnt}/${data_subdir}"/grub*/ && cp grub.cfg.example grub.cfg ) \
     || cleanUp 10
 
 # Download memdisk
 wget -qO - \
     'https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.gz' \
-    | tar -xz -C "${data_mnt}"/boot/grub*/ --no-same-owner --strip-components 3 \
+    | tar -xz -C "${data_mnt}/${data_subdir}"/grub*/ --no-same-owner --strip-components 3 \
     'syslinux-6.03/bios/memdisk/memdisk' \
     || cleanUp 10
 


### PR DESCRIPTION
As long as grub-install is given the correct path, installing the GRUB files to "`$DATA_MOUNTPOINT/boot/grub`" is no different than installing to "`$DATA_MOUNTPOINT/$SOMETHING/grub`" even in the special case that `SOMETHING=.`. This patch to makeUSB.sh allows for using values of `$SOMETHING` other than "`boot`".

Indeed, putting the "grub" directory directly under the flash-drive data-partition's root is my primary motivation for this flexibility: I desire a multiboot USB drive that can also serve as the bootloader for a Linux install on the internal disk-drive. Most distros's "rerun grub-mkconfig when grub is updated" functionalities assume that when the boot partition (in my case, the USB drive's data partition) is mounted at `/boot` then the bootloader files are available at the absolute path `/boot/grub` (so "grub" is at the root of the filesystem mounted at "/boot") rather than at `/boot/boot/grub` (which is what results from running makeUSB as-is).

However, I'm not entirely certain on the naming of the new command-line option that this patch adds.
