### PR TITLE
Support for all 6 grml iso files.

### DIFF
--- a/mbusb.d/grml.d/generic.cfg
+++ b/mbusb.d/grml.d/generic.cfg
@@ -1,4 +1,4 @@
-for isofile in $isopath/grml96-*.iso; do
+for isofile in $isopath/grml*.iso; do
   if [ -e "$isofile" ]; then
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname (loopback.cfg) ->" "$isofile" {


### PR DESCRIPTION
../grml.d/generic96.cfg only works with the combined 32/4bit ISO files (small or full). This change recognizes and loads the 64bit and 32bit only ISO files as well as the combined ones. Fixes issue #154 .