### PR TITLE
Docs for distros of ZeTriUm

### DIFF
--- a/docs/_linux/archlabs.md
+++ b/docs/_linux/archlabs.md
@@ -1,0 +1,40 @@
+---
+title: ArchLabs
+homepage: https://archlabslinux.com/
+download: https://archlabslinux.com/get-archlabs-2/
+cfgdir: archlabs.d
+layout: default
+---
+
+# {{ page.title }}
+
+> ArchLabs is a distribution based on Arch Linux and featuring the Openbox
+> window manager as the primary desktop interface. ArchLabs is a 64-bit, rolling
+> release distribution which provides a live DVD. The distribution can be
+> installed using the ABIF system installer.
+>
+> -- <cite markdown="1">[DistroWatch][]</cite>
+
+
+{% if page.cfgdir %}
+## Configuration
+
+- [Project's files for {{ page.title }}][config]
+{% endif %}
+
+
+## Supported releases
+
+- Live ISO(64-bit,NBD,NFS,HTTP,Memtest86+)
+
+## Links
+
+- [Official homepage]({{ page.homepage }})
+- [Official download page]({{ page.download }})
+- [{{ page.title }} at DistroWatch][distrowatch]
+- [{{ page.title }} at Wikipedia][wikipedia]
+
+
+[config]: {{ site.github.repository_url | append: "/tree/master/mbusb.d/" | append: page.cfgdir }}
+[distrowatch]: https://distrowatch.com/table.php?distribution=archlabs
+[wikipedia]: https://en.wikipedia.org/wiki/ArchLabs

--- a/docs/_linux/archstrike.md
+++ b/docs/_linux/archstrike.md
@@ -1,0 +1,38 @@
+---
+title: ArchStrike
+homepage: https://archstrike.org/
+download: https://archstrike.org/downloads
+cfgdir: archstrike.d
+layout: default
+---
+
+# {{ page.title }}
+
+> ArchStrike is a distribution for security professionals and researchers based
+> on Arch Linux. ArchStrike provides an extra repository of security software
+> and is available in 32-bit and 64-bit builds. ArchStrike provides a live
+> desktop environment based on the Openbox window manager.
+>
+> -- <cite markdown="1">[DistroWatch][]</cite>
+
+
+{% if page.cfgdir %}
+## Configuration
+
+- [Project's files for {{ page.title }}][config]
+{% endif %}
+
+
+## Supported releases
+
+- Live ISO(64-bit)
+
+## Links
+
+- [Official homepage]({{ page.homepage }})
+- [Official download page]({{ page.download }})
+- [{{ page.title }} at DistroWatch][distrowatch]
+
+
+[config]: {{ site.github.repository_url | append: "/tree/master/mbusb.d/" | append: page.cfgdir }}
+[distrowatch]: https://distrowatch.com/table.php?distribution=archstrike

--- a/docs/_linux/chakra.md
+++ b/docs/_linux/chakra.md
@@ -1,0 +1,40 @@
+---
+title: Chakra Linux
+homepage: https://www.chakralinux.org/
+download: https://www.chakralinux.org/
+cfgdir: chakra.d
+layout: default
+---
+
+# {{ page.title }}
+
+> Chakra GNU/Linux is a user-friendly and powerful distribution and live CD
+> originally forked from Arch Linux. It features a graphical installer,
+> automatic hardware detection and configuration, the latest KDE desktop, and a
+> variety of tools and extras.
+>
+> -- <cite markdown="1">[DistroWatch][]</cite>
+
+
+{% if page.cfgdir %}
+## Configuration
+
+- [Project's files for {{ page.title }}][config]
+{% endif %}
+
+
+## Supported releases
+
+- Live ISO
+
+## Links
+
+- [Official homepage]({{ page.homepage }})
+- [Official download page]({{ page.download }})
+- [{{ page.title }} at DistroWatch][distrowatch]
+- [{{ page.title }} at Wikipedia][wikipedia]
+
+
+[config]: {{ site.github.repository_url | append: "/tree/master/mbusb.d/" | append: page.cfgdir }}
+[distrowatch]: https://distrowatch.com/table.php?distribution=chakra
+[wikipedia]: https://gl.wikipedia.org/wiki/Chakra_GNU/Linux

--- a/docs/_linux/geckolinux.md
+++ b/docs/_linux/geckolinux.md
@@ -1,0 +1,42 @@
+---
+title: GeckoLinux
+homepage: https://geckolinux.github.io/
+download: https://geckolinux.github.io/#download
+cfgdir: gecko.d
+layout: default
+---
+
+# {{ page.title }}
+
+> GeckoLinux is a Linux spin based on the openSUSE distribution, with a focus on
+> polish and out-of-the-box usability on the desktop. The distribution features
+> many desktop editions which can be installed from live discs. Some patent
+> encumbered open source software is included in GeckoLinux which is not
+> available in the default installation of openSUSE. Special attention has been
+> given to the quality of the font rendering. GeckoLinux provides two main
+> editions, Static (which is based on openSUSE Leap) and Rolling
+> (based on openSUSE Tumbleweed).
+>
+> -- <cite markdown="1">[DistroWatch][]</cite>
+
+
+{% if page.cfgdir %}
+## Configuration
+
+- [Project's files for {{ page.title }}][config]
+{% endif %}
+
+
+## Supported releases
+
+- All ISOs?
+
+## Links
+
+- [Official homepage]({{ page.homepage }})
+- [Official download page]({{ page.download }})
+- [{{ page.title }} at DistroWatch][distrowatch]
+
+
+[config]: {{ site.github.repository_url | append: "/tree/master/mbusb.d/" | append: page.cfgdir }}
+[distrowatch]: https://distrowatch.com/table.php?distribution=gecko

--- a/docs/_linux/mauilinux.md
+++ b/docs/_linux/mauilinux.md
@@ -1,0 +1,42 @@
+---
+title: Maui Linux
+homepage: https://mauilinux.org/
+download: https://mauilinux.org/download/
+cfgdir: maui.d
+layout: default
+---
+
+# {{ page.title }}
+
+> Maui Linux is a desktop Linux distribution based on KDE neon and featuring
+> KDE's Plasma desktop. It was created in August 2016 as a continuation of
+> Netrunner's Kubuntu-based "Desktop" edition, but it was re-based on KDE neon
+> which is a more cutting-edge project with frequent updates and a semi-rolling
+> release model. Besides providing a KDE-centric distribution with many popular
+> KDE packages included on the live DVD, the project also focuses on integrating
+> non-KDE software, such as Firefox, Thunderbird or VLC with the underlying
+> infrastructure of the Plasma desktop.
+>
+> -- <cite markdown="1">[DistroWatch][]</cite>
+
+
+{% if page.cfgdir %}
+## Configuration
+
+- [Project's files for {{ page.title }}][config]
+{% endif %}
+
+
+## Supported releases
+
+- Live ISO
+
+## Links
+
+- [Official homepage]({{ page.homepage }})
+- [Official download page]({{ page.download }})
+- [{{ page.title }} at DistroWatch][distrowatch]
+
+
+[config]: {{ site.github.repository_url | append: "/tree/master/mbusb.d/" | append: page.cfgdir }}
+[distrowatch]: https://distrowatch.com/table.php?distribution=maui

--- a/docs/_linux/robolinux.md
+++ b/docs/_linux/robolinux.md
@@ -1,0 +1,41 @@
+---
+title: RoboLinux
+homepage: https://www.robolinux.org/
+download: https://sourceforge.net/projects/robolinux/files/
+cfgdir: robolinux.d
+layout: default
+---
+
+# {{ page.title }}
+
+> Robolinux is a user-friendly and intuitive operating system based on the
+> latest long term support release of Ubuntu. One of the project's more
+> interesting features is the availability of a pre-configured virtual machine
+> support pack with Windows XP or Windows 7 - a VirtualBox setup which allows
+> the user to install and run the Windows operating system seamlessly alongside
+> Robolinux. This is an optional add-on that must be downloaded from the
+> project's online store.
+>
+> -- <cite markdown="1">[DistroWatch][]</cite>
+
+
+{% if page.cfgdir %}
+## Configuration
+
+- [Project's files for {{ page.title }}][config]
+{% endif %}
+
+
+## Supported releases
+
+- Live ISO
+
+## Links
+
+- [Official homepage]({{ page.homepage }})
+- [Official download page]({{ page.download }})
+- [{{ page.title }} at DistroWatch][distrowatch]
+
+
+[config]: {{ site.github.repository_url | append: "/tree/master/mbusb.d/" | append: page.cfgdir }}
+[distrowatch]: https://distrowatch.com/table.php?distribution=robolinux

--- a/docs/_linux/runtu.md
+++ b/docs/_linux/runtu.md
@@ -1,0 +1,40 @@
+---
+title: Runtu
+homepage: http://runtu.org/
+download: http://runtu.org/runtu/download.html
+cfgdir: runtu.d
+layout: default
+---
+
+# {{ page.title }}
+
+> Runtu is a Russian desktop Linux distribution based on Ubuntu's LTS
+> (long-ter support) releases. It features full support for Russian and a
+> variety of extra applications, tools and media codecs. There are two separate
+> editions that are produced with a varying degree of frequency; the "Xfce"
+> edition tend to get more attention while the "Lite" edition, featuring the
+> LXDE desktop, is also released and updated from time to time.
+>
+> -- <cite markdown="1">[DistroWatch][]</cite>
+
+
+{% if page.cfgdir %}
+## Configuration
+
+- [Project's files for {{ page.title }}][config]
+{% endif %}
+
+
+## Supported releases
+
+- Live ISO
+
+## Links
+
+- [Official homepage]({{ page.homepage }})
+- [Official download page]({{ page.download }})
+- [{{ page.title }} at DistroWatch][distrowatch]
+
+
+[config]: {{ site.github.repository_url | append: "/tree/master/mbusb.d/" | append: page.cfgdir }}
+[distrowatch]: https://distrowatch.com/table.php?distribution=runtu


### PR DESCRIPTION
I want to document all the distros added by @ZeTriUm. But since they are quit a few it still in progress:

- [x] #187  GeckoLinux
- [x] #186 ArchLabs 
- [x] #185  Maui Linux
- [x] #184 ArchStrike
- [x] #183 Runtu 
- [x] #182 Chakra GNU/Linux 
- [x] #181 RoboLinux
- [ ] #180 Scientific Linux
- [ ] #179 Calculate Linux
- [ ] #178 SolydXK
- [ ] #177 OSGeo-Live
- [ ] #176 Siduction
- [ ] #175 JanusLinux
- [ ] #174  Musix GNU+Linux
- [ ] #173 Liquid Lemur Linux
- [ ] #172 OPNsense
- [ ] #171 Exton Linux Live
- [ ] #170 Voyager
- [ ] #169 Revenge OS
- [ ] #168 Red Flag Linux
- [ ] #167 Qomo Linux
- [ ] #166 Phoenix OS
- [ ] #164 LinHES
- [ ] #163 ClearOS
- [ ] #162 Bluestar Linux
- [ ] #161 Bliss OS
- [ ] #160 Plop Linux
- [ ] #159 Pop!_OS
- [ ] #158 Ubuntu Kylin
- [ ] #157 Emmabuntüs
- [ ] #156 CyanogenMod

If you want to help:

The documentation files are written in Markdown and generated by [Jekyll](https://jekyllrb.com/).
They can be tested by installing [Ruby](https://www.ruby-lang.org) and running:

```
gem install jekyll bundler github-pages
cd multibootusb/docs
bundle exec jekyll serve
```  