### PR TITLE
Find win7 partition; explain if can't find configfile; instructions

### DIFF
--- a/mbusb.cfg
+++ b/mbusb.cfg
@@ -39,4 +39,33 @@ submenu "Multiboot ->" {
     done
   }
 
+  # Use MEMDISK to load ISO files
+  submenu "Use MEMDISK to boot ISO files ->" {
+    echo -n "Looking for ISO files... "
+    for isofile in $isopath/*.iso; do
+      if [ -e "$isofile" ]; then
+        regexp --set=isoname "$isopath/(.*)" "$isofile"
+        menuentry "$isoname" "$isofile" {
+          iso_path="$2"
+          bootoptions="iso raw"
+          linux16 $prefix/memdisk $bootoptions
+          initrd16 $iso_path
+        }
+      fi
+    done
+    echo
+    echo -n "Looking for ISO files... "
+    for imgfile in $isopath/*.img; do
+      if [ -e "$imgfile" ]; then
+        regexp --set=imgname "$isopath/(.*)" "$imgfile"
+        menuentry "$imgname" "$imgfile" {
+          img_path="$2"
+          bootoptions="raw"
+          linux16 $prefix/memdisk $bootoptions
+          initrd16 $img_path
+        }
+      fi
+    done
+  }
+
 }

--- a/mbusb.cfg
+++ b/mbusb.cfg
@@ -21,6 +21,7 @@ fi
 # Function to look for boot files
 function search_files {
   root="$1"
+  found=""
 
   insmod bitmap
   insmod jpeg
@@ -33,6 +34,7 @@ function search_files {
     /boot/grub/x86_64-efi/grub.cfg \
     /EFI/BOOT/grub.cfg; do
     if [ -e "$grubfile" ]; then
+      found="found"
       menuentry "GRUB boot ($grubfile)" "$grubfile" {
         grub_file="$2"
         configfile "$grub_file"
@@ -52,6 +54,7 @@ function search_files {
     /boot/syslinux/isolinux.cfg \
     /boot/syslinux/syslinux.cfg; do
     if [ -e "$syslinuxfile" ]; then
+      found="found"
       menuentry "SYSLINUX boot ($syslinuxfile)" "$syslinuxfile" {
         syslinux_file="$2"
         syslinux_configfile -i "$syslinux_file"
@@ -63,6 +66,7 @@ function search_files {
     /boot/grub/menu.lst \
     /menu.lst; do
     if [ -e "$legacyfile" ]; then
+      found="found"
       menuentry "GRUB legacy boot ($legacyfile)" "$legacyfile" {
         legacy_file="$2"
         legacy_configfile "$legacy_file"
@@ -71,14 +75,21 @@ function search_files {
   done
 
   if [ "x$grub_platform" == "xefi" ]; then
-    for efifile in /efi/boot/bootx64.efi; do
+    for efifile in \
+      /efi/boot/bootx64.efi \
+      /efi/microsoft/boot/bootmgfw.efi; do
       if [ -e "$efifile" ]; then
+        found="found"
         menuentry "EFI boot ($efifile)" "$efifile" {
           efi_file="$2"
           chainloader "$efi_file"
         }
       fi
     done
+  fi
+  if [ "x$found" == "x" ]; then
+    echo "no bootable things found on $root"
+    sleep -v -i 5
   fi
 
 }

--- a/mbusb.cfg
+++ b/mbusb.cfg
@@ -18,6 +18,7 @@ fi
 
 # MultiBoot USB menu
 submenu "Multiboot ->" {
+
   # Warning for 32-bit systems
   if ! cpuid -l; then
     clear
@@ -30,9 +31,12 @@ submenu "Multiboot ->" {
     echo
   fi
 
-  # Load configuration files
-  echo -n "Loading configuration files... "
-  for cfgfile in $prefix/mbusb.d/*.d/*.cfg; do
-    source "$cfgfile"
-  done
+  # Load configuration for ISO/kernel files
+  submenu "Boot supported ISO/kernel files ->" {
+    echo -n "Loading configuration files... "
+    for cfgfile in $prefix/mbusb.d/*.d/*.cfg; do
+      source "$cfgfile"
+    done
+  }
+
 }

--- a/mbusb.cfg
+++ b/mbusb.cfg
@@ -1,7 +1,9 @@
 # Partition holding files
+regexp --set=rootdisk "^(.*),.*" "$root"
+regexp --set=rootpartnum "^.*,.*([0-9]+)" "$root"
 probe -u $root --set=rootuuid
 set imgdevpath="/dev/disk/by-uuid/$rootuuid"
-export imgdevpath rootuuid
+export imgdevpath rootuuid rootdisk rootpartnum
 
 # Custom variables
 set isopath="/boot/isos"
@@ -67,6 +69,18 @@ function search_files {
       }
     fi
   done
+
+  if [ "x$grub_platform" == "xefi" ]; then
+    for efifile in /efi/boot/bootx64.efi; do
+      if [ -e "$efifile" ]; then
+        menuentry "EFI boot ($efifile)" "$efifile" {
+          efi_file="$2"
+          chainloader "$efi_file"
+        }
+      fi
+    done
+  fi
+
 }
 
 # MultiBoot USB menu
@@ -89,6 +103,22 @@ submenu "Multiboot ->" {
     echo -n "Loading configuration files... "
     for cfgfile in $prefix/mbusb.d/*.d/*.cfg; do
       source "$cfgfile"
+    done
+  }
+
+  # Search partitions for boot files
+  submenu "Auto-detect bootable partitions ->" {
+    echo -n "Searching pendrive's partitions... "
+    for part in ($rootdisk,*); do
+      regexp --set=partnum "^.*,.*([0-9]+)" "$part"
+      if [ "$partnum" -le "$rootpartnum" ]; then continue; fi
+      submenu "$part ->" "$part" {
+        part_name="$2"
+        probe --fs-uuid $part_name --set=part_uuid
+        search --fs-uuid --no-floppy --hint=$part_name --set=root $part_uuid
+        # Look for boot files
+        search_files $root
+      }
     done
   }
 

--- a/mbusb.cfg
+++ b/mbusb.cfg
@@ -16,6 +16,59 @@ if [ -e "$prefix/mbusb.cfg.local" ]; then
   source "$prefix/mbusb.cfg.local"
 fi
 
+# Function to look for boot files
+function search_files {
+  root="$1"
+
+  insmod bitmap
+  insmod jpeg
+  insmod png
+  insmod tga
+
+  for grubfile in \
+    /boot/grub/loopback.cfg \
+    /boot/grub/grub.cfg \
+    /boot/grub/x86_64-efi/grub.cfg \
+    /EFI/BOOT/grub.cfg; do
+    if [ -e "$grubfile" ]; then
+      menuentry "GRUB boot ($grubfile)" "$grubfile" {
+        grub_file="$2"
+        configfile "$grub_file"
+      }
+    fi
+  done
+
+  for syslinuxfile in \
+    /isolinux.cfg \
+    /syslinux.cfg \
+    /isolinux/isolinux.cfg \
+    /isolinux/syslinux.cfg \
+    /syslinux/isolinux.cfg \
+    /boot/isolinux.cfg \
+    /boot/isolinux/isolinux.cfg \
+    /boot/syslinux.cfg \
+    /boot/syslinux/isolinux.cfg \
+    /boot/syslinux/syslinux.cfg; do
+    if [ -e "$syslinuxfile" ]; then
+      menuentry "SYSLINUX boot ($syslinuxfile)" "$syslinuxfile" {
+        syslinux_file="$2"
+        syslinux_configfile -i "$syslinux_file"
+      }
+    fi
+  done
+
+  for legacyfile in \
+    /boot/grub/menu.lst \
+    /menu.lst; do
+    if [ -e "$legacyfile" ]; then
+      menuentry "GRUB legacy boot ($legacyfile)" "$legacyfile" {
+        legacy_file="$2"
+        legacy_configfile "$legacy_file"
+      }
+    fi
+  done
+}
+
 # MultiBoot USB menu
 submenu "Multiboot ->" {
 
@@ -36,6 +89,25 @@ submenu "Multiboot ->" {
     echo -n "Loading configuration files... "
     for cfgfile in $prefix/mbusb.d/*.d/*.cfg; do
       source "$cfgfile"
+    done
+  }
+
+  # Search ISO files for boot files
+  submenu "Auto-detect ISO's configfiles ->" {
+    echo -n "Looking for ISO files... "
+    for isofile in $isopath/*.iso $isopath/*.img; do
+      if [ -e "$isofile" ]; then
+        regexp --set=isoname "$isopath/(.*)" "$isofile"
+        submenu "$isoname ->" "$isofile" {
+          iso_path="$2"
+          export iso_path
+          search --set=root --file "$iso_path"
+          loopback loop "$iso_path"
+          root=(loop)
+          # Look for boot files
+          search_files $root
+        }
+      fi
     done
   }
 


### PR DESCRIPTION
If someone uses "Auto-detect ISO's configfiles" or "Auto-detect bootable
partitions" and it doesn't find anything it just blinks and is
confusing, so this shows a message and waits 5 seconds.

This also searches for `/efi/microsoft/boot/bootdmgfw.efi` which should
be the efi boot file for a windows 7 installer.



The other half of this pull request is a starting point for instructions to put a win7 installer in in UEFI mode.
All the documentation seems to be in the website, so instructions are here:

* Install OVMF.
* Install multiboot to a flash drive, make sure to have efi enabled with `-b -e`.
    Non-hybrid efi mode should work as well.
* Re-partition the drive to have a chunk big enough to contain the contents of your windows iso.
* Format as FAT32 or NTFS, both seem to work
* Copy your iso contents to the partition.
* Copy `bootmgfw.efi` from `C:\Windows\Boot\EFI\bootmgfw.efi` on a running win7 system, or extract it out of `<iso mount point>/sources/install.wim`
* Start qemu in efi mode with
    The `OVMF.fd` location used below is for debian stretch, may be platform dependant.
```
sudo qemu-system-x86_64 -localtime -m 2G -vga std --bios /usr/share/ovmf/OVMF.fd -drive file=<device>,readonly,cache=none,format=raw,if=virtio
```
* Select "Multiboot" and then  "Auto-detect bootable partitions" and it should show up and boot.