### PR TITLE
Fix Ubuntu Server Live ISO script

### DIFF
--- a/mbusb.d/ubuntu.d/server-generic.cfg
+++ b/mbusb.d/ubuntu.d/server-generic.cfg
@@ -8,12 +8,12 @@ for isofile in $isopath/ubuntu-*-live-server-amd64.iso; do
       menuentry "Install Ubuntu Server" {
         set gfxpayload=keep
         linux	(loop)/casper/vmlinuz   boot=casper iso-scan/filename=${iso_path} quiet  ---
-        initrd	(loop)/casper/initrd
+        initrd	(loop)/casper/initrd*
       }
 
       menuentry "Check disc for defects" {
         linux	(loop)/casper/vmlinuz  boot=casper integrity-check iso-scan/filename=${iso_path} quiet splash ---
-        initrd	(loop)/casper/initrd
+        initrd	(loop)/casper/initrd*
       }
 
       # blackscreen?

--- a/mbusb.d/ubuntu.d/server-generic.cfg
+++ b/mbusb.d/ubuntu.d/server-generic.cfg
@@ -8,12 +8,12 @@ for isofile in $isopath/ubuntu-*-live-server-amd64.iso; do
       menuentry "Install Ubuntu Server" {
         set gfxpayload=keep
         linux	(loop)/casper/vmlinuz   boot=casper iso-scan/filename=${iso_path} quiet  ---
-        initrd	(loop)/casper/initrd.gz
+        initrd	(loop)/casper/initrd
       }
 
       menuentry "Check disc for defects" {
         linux	(loop)/casper/vmlinuz  boot=casper integrity-check iso-scan/filename=${iso_path} quiet splash ---
-        initrd	(loop)/casper/initrd.gz
+        initrd	(loop)/casper/initrd
       }
 
       # blackscreen?


### PR DESCRIPTION
On Ubuntu Server 18.04 the initrd image file in /casper has no extension, the script was instead assuming a ".gz" one. I checked if that was the case for Ubuntu 16.04, but in that distro there is no /casper at all. The fix should work from 18.04 onwards.