### PR TITLE
mbusb.d: fedora: Allow recognition of netinstall isos

### DIFF
--- a/mbusb.d/fedora.d/server-generic.cfg
+++ b/mbusb.d/fedora.d/server-generic.cfg
@@ -1,4 +1,4 @@
-for isofile in $isopath/Fedora-Server-dvd-*.iso; do
+for isofile in $isopath/Fedora-Server-*.iso; do
   if [ -e "$isofile" ]; then
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname ->" "$isofile" {

--- a/mbusb.d/fedora.d/workstation-generic.cfg
+++ b/mbusb.d/fedora.d/workstation-generic.cfg
@@ -1,4 +1,4 @@
-for isofile in $isopath/Fedora-Workstation-Live-*.iso; do
+for isofile in $isopath/Fedora-Workstation-*.iso; do
   if [ -e "$isofile" ]; then
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname ->" "$isofile" {


### PR DESCRIPTION
Both configs were strictly matching either '-dvd-*.iso' or '-Live-*.iso'.
That means however, that none of the netinstall isos will be found
during the drive iso scan.

Signed-off-by: Erik Skultety <eskultet@redhat.com>