### PR TITLE
Fix non-fatal error when using the --clone parameter

### DIFF
--- a/makeUSB.sh
+++ b/makeUSB.sh
@@ -284,8 +284,10 @@ mkdir -p "${data_mnt}/${data_subdir}/isos" || cleanUp 10
 if [ "$clone" -eq 1 ]; then
 	# Clone Git repository
 	(cd "$repo_dir" && \
-	    git clone https://github.com/aguslr/multibootusb . && \
-	    mv .git* * "${data_mnt}/${data_subdir}"/grub*/) \
+		git clone https://github.com/aguslr/multibootusb . && \
+		# Move all visible and hidden files and folders except '.' and '..'
+		for x in * .[!.]* ..?*; do if [ -e "$x" ]; then mv -- "$x" \
+			"${data_mnt}/${data_subdir}"/grub*/; fi; done) \
 	    || cleanUp 10
 else
 	# Copy files


### PR DESCRIPTION
See commit message.

Previous code suspiciously looks like it was intended to only move hidden files starting with `.git`. If that was really the reason (I can't imagine why though) a different approach might be needed.

Cheers