### PR TITLE
Updated BlackArch iso name

### DIFF
--- a/mbusb.d/blackarch.d/generic.cfg
+++ b/mbusb.d/blackarch.d/generic.cfg
@@ -1,4 +1,4 @@
-for isofile in $isopath/blackarchlinux-*.iso; do
+for isofile in $isopath/blackarch-linux-*.iso; do
   if [ -e "$isofile" ]; then
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname ->" "$isofile" {


### PR DESCRIPTION
The BlackArch ISO naming system has been changed to include a dash.